### PR TITLE
fix: weapon data not being updated properly

### DIFF
--- a/SAIN/Classes/Player/Equipment/WeaponInfo.cs
+++ b/SAIN/Classes/Player/Equipment/WeaponInfo.cs
@@ -90,7 +90,7 @@ public class WeaponInfo
         MuzzleLoudness += FlashHider?.Loudness ?? 0f;
         BulletSpeed = Weapon.CurrentAmmoTemplate.InitialSpeed * Weapon.SpeedFactor;
         CalculatedAudibleRange = BaseAudibleRange + MuzzleLoudness;
-        if (Suppressor != null || (Player.HandsController is Player.FirearmController firearmController && firearmController.IsSilenced))
+        if (Suppressor != null)
         {
             CalculatedAudibleRange *= SuppressorModifier(BulletSpeed);
             HasSuppressor = true;

--- a/SAIN/Classes/Player/Equipment/WeaponInfo.cs
+++ b/SAIN/Classes/Player/Equipment/WeaponInfo.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using EFT;
 using EFT.InventoryLogic;
 using SAIN.Helpers;
@@ -90,7 +91,7 @@ public class WeaponInfo
         MuzzleLoudness += FlashHider?.Loudness ?? 0f;
         BulletSpeed = Weapon.CurrentAmmoTemplate.InitialSpeed * Weapon.SpeedFactor;
         CalculatedAudibleRange = BaseAudibleRange + MuzzleLoudness;
-        if (Suppressor != null)
+        if (Suppressor != null || _suppressedWeapons.Contains(Weapon.TemplateId.StringID))
         {
             CalculatedAudibleRange *= SuppressorModifier(BulletSpeed);
             HasSuppressor = true;

--- a/SAIN/Classes/Player/Equipment/WeaponInfo.cs
+++ b/SAIN/Classes/Player/Equipment/WeaponInfo.cs
@@ -132,25 +132,19 @@ public class WeaponInfo
                 switch (modType)
                 {
                     case EModType.RedDot:
-                        if (RedDot == null)
-                        {
-                            RedDot = mod;
-                        }
+                        RedDot ??= mod;
                         break;
                     case EModType.Optic:
-                        if (Optic == null)
-                        {
-                            Optic = mod;
-                        }
+                        Optic ??= mod;
                         break;
                     case EModType.FlashHider:
-                        if (FlashHider == null)
-                        {
-                            FlashHider = mod;
-                        }
+                        FlashHider ??= mod;
                         break;
                     case EModType.Suppressor:
-                        if (Suppressor == null)
+                        Suppressor ??= mod;
+                        break;
+                    default:
+                        if (Suppressor == null && _suppressorMods.Contains(mod.TemplateId.StringID))
                         {
                             Suppressor = mod;
                         }
@@ -289,6 +283,12 @@ public class WeaponInfo
     private static readonly string[] _suppressedWeapons =
     {
         "674d6121c09f69dfb201a888" // Aklys Defense Velociraptor .300
+    };
+
+    // Some mods are suppressors, but aren't classified as suppressors.
+    private static readonly string[] _suppressorMods =
+    {
+        "5888945a2459774bf43ba385" // DVL-10 suppressed barrel
     };
 }
 

--- a/SAIN/Classes/Player/Equipment/WeaponInfo.cs
+++ b/SAIN/Classes/Player/Equipment/WeaponInfo.cs
@@ -44,12 +44,13 @@ public class WeaponInfo
 
     public bool HasSuppressor { get; private set; }
     public float BaseAudibleRange { get; private set; } = 150f;
-    public float MuzzleLoudness { get; private set; }
+    public float MuzzleLoudness { get; private set; } = 0f;
     public bool Subsonic
     {
         get { return Weapon != null && BulletSpeed < SuperSonicSpeed; }
     }
 
+    public Mod FlashHider { get; private set; }
     public Mod Suppressor { get; private set; }
     public Mod RedDot { get; private set; }
     public Mod Optic { get; private set; }
@@ -83,10 +84,10 @@ public class WeaponInfo
 
     private void UpdateWeaponData(Player Player, IEnumerable<Mod> mods)
     {
-        Suppressor = FindModType(mods, EModType.Suppressor);
-        RedDot = FindModType(mods, EModType.RedDot);
-        Optic = FindModType(mods, EModType.Optic);
-        MuzzleLoudness = Suppressor != null ? Suppressor.Template.Loudness : 0f;
+        FindModType(mods);
+        MuzzleLoudness = 0f;
+        MuzzleLoudness += Suppressor?.Loudness ?? 0f;
+        MuzzleLoudness += FlashHider?.Loudness ?? 0f;
         BulletSpeed = Weapon.CurrentAmmoTemplate.InitialSpeed * Weapon.SpeedFactor;
         CalculatedAudibleRange = BaseAudibleRange + MuzzleLoudness;
         if (Suppressor != null || (Player.HandsController is Player.FirearmController firearmController && firearmController.IsSilenced))
@@ -116,28 +117,55 @@ public class WeaponInfo
         PresetHandler.OnPresetUpdated -= updateSettings;
     }
 
-    private static Mod FindModType(IEnumerable<Mod> mods, EModType ModType)
+    private void FindModType(IEnumerable<Mod> mods)
     {
+        RedDot = null;
+        Optic = null;
+        FlashHider = null;
+        Suppressor = null;
         if (mods != null)
         {
             foreach (Mod mod in mods)
             {
-                if (CheckItemType(mod.GetType()) == ModType)
+                var modType = CheckItemType(mod.GetType());
+                switch (modType)
                 {
-                    return mod;
+                    case EModType.RedDot:
+                        if (RedDot == null)
+                        {
+                            RedDot = mod;
+                        }
+                        break;
+                    case EModType.Optic:
+                        if (Optic == null)
+                        {
+                            Optic = mod;
+                        }
+                        break;
+                    case EModType.FlashHider:
+                        if (FlashHider == null)
+                        {
+                            FlashHider = mod;
+                        }
+                        break;
+                    case EModType.Suppressor:
+                        if (Suppressor == null)
+                        {
+                            Suppressor = mod;
+                        }
+                        break;
                 }
 
-                Slot[] Slots = mod.Slots;
-                foreach (Slot slot in Slots)
+                if (RedDot != null
+                    && Optic != null
+                    && FlashHider != null
+                    && Suppressor != null
+                )
                 {
-                    if (slot.ContainedItem is Mod ContainedMod && CheckItemType(ContainedMod.GetType()) == ModType)
-                    {
-                        return ContainedMod;
-                    }
+                    return;
                 }
             }
         }
-        return null;
     }
 
     private static float SuppressorModifier(float bulletspeed)
@@ -151,6 +179,10 @@ public class WeaponInfo
 
     private static EModType CheckItemType(Type type)
     {
+        if (CheckTemplateType(type, FlashHiderTypeId))
+        {
+            return EModType.FlashHider;
+        }
         if (CheckTemplateType(type, SuppressorTypeId))
         {
             return EModType.Suppressor;
@@ -209,7 +241,7 @@ public class WeaponInfo
     {
         Logger.LogDebug(
             $"Found Weapon Info: "
-                + $"Weapon: [{Weapon.ShortName}] "
+                + $"Weapon: [{Weapon.ShortName.Localized()}] "
                 + $"Weapon Class: [{WeaponClass}] "
                 + $"Ammo Caliber: [{AmmoCaliber}] "
                 + $"Calculated Audible Range: [{CalculatedAudibleRange}] "
@@ -221,12 +253,22 @@ public class WeaponInfo
                 + $"Has Optic? [{HasOptic}] "
                 + $"Has Suppressor? [{HasSuppressor}]"
         );
+
+        Logger.LogDebug(
+            $"Found Weapon Info (continue):"
+                + $" Suppressor: [{Suppressor?.ShortName.Localized()}]"
+                + $" Flash Hider: [{FlashHider?.ShortName.Localized()}]"
+                + $" Optic: [{Optic?.ShortName.Localized()}]"
+                + $" Red dot: [{RedDot?.ShortName.Localized()}]"
+        );
     }
 
     private const float SuperSonicSpeed = 343.2f;
 
-    //private static readonly string FlashHiderTypeId = "550aa4bf4bdc2dd6348b456b";
+    // Contrary to the name, Muzzle here means "Muzzle Device", i.e., the parent of flash hiders and suppressors.
+    // Muzzle brake is also considered a "FlashHider".
     //private static readonly string MuzzleTypeId = "5448fe394bdc2d0d028b456c";
+    private static readonly string FlashHiderTypeId = "550aa4bf4bdc2dd6348b456b";
     private static readonly string SuppressorTypeId = "550aa4cd4bdc2dd8348b456c";
 
     private static readonly string CollimatorTypeId = "55818ad54bdc2ddc698b4569";
@@ -245,6 +287,7 @@ public enum EModType
     Suppressor,
     RedDot,
     Optic,
+    FlashHider,
 }
 
 public class OpticAIConfig

--- a/SAIN/Classes/Player/Equipment/WeaponInfo.cs
+++ b/SAIN/Classes/Player/Equipment/WeaponInfo.cs
@@ -15,8 +15,8 @@ public class WeaponInfo
         Weapon = weapon;
         WeaponClass = TryGetWeaponClass(weapon);
         AmmoCaliber = TryGetAmmoCaliber(weapon);
-        updateSettings(SAINPresetClass.Instance);
-        PresetHandler.OnPresetUpdated += updateSettings;
+        UpdateSettings(SAINPresetClass.Instance);
+        PresetHandler.OnPresetUpdated += UpdateSettings;
     }
 
     public EWeaponClass WeaponClass { get; private set; }
@@ -62,7 +62,7 @@ public class WeaponInfo
         get { return Weapon.Repairable.Durability / (float)Weapon.Repairable.TemplateDurability; }
     }
 
-    private void updateSettings(SAINPresetClass preset)
+    private void UpdateSettings(SAINPresetClass preset)
     {
         if (preset.GlobalSettings.Shoot.EngagementDistance.TryGetValue(WeaponClass, out float distance))
         {
@@ -114,7 +114,7 @@ public class WeaponInfo
 
     public void Dispose()
     {
-        PresetHandler.OnPresetUpdated -= updateSettings;
+        PresetHandler.OnPresetUpdated -= UpdateSettings;
     }
 
     private void FindModType(IEnumerable<Mod> mods)
@@ -179,24 +179,24 @@ public class WeaponInfo
 
     private static EModType CheckItemType(Type type)
     {
-        if (CheckTemplateType(type, FlashHiderTypeId))
+        if (CheckTemplateType(type, _flashHiderTypeId))
         {
             return EModType.FlashHider;
         }
-        if (CheckTemplateType(type, SuppressorTypeId))
+        if (CheckTemplateType(type, _suppressorTypeId))
         {
             return EModType.Suppressor;
         }
-        for (int i = 0; i < RedDotTypes.Length; i++)
+        for (int i = 0; i < _redDotTypes.Length; i++)
         {
-            if (CheckTemplateType(type, RedDotTypes[i]))
+            if (CheckTemplateType(type, _redDotTypes[i]))
             {
                 return EModType.RedDot;
             }
         }
-        for (int i = 0; i < OpticTypes.Length; i++)
+        for (int i = 0; i < _opticTypes.Length; i++)
         {
-            if (CheckTemplateType(type, OpticTypes[i]))
+            if (CheckTemplateType(type, _opticTypes[i]))
             {
                 return EModType.Optic;
             }
@@ -268,17 +268,27 @@ public class WeaponInfo
     // Contrary to the name, Muzzle here means "Muzzle Device", i.e., the parent of flash hiders and suppressors.
     // Muzzle brake is also considered a "FlashHider".
     //private static readonly string MuzzleTypeId = "5448fe394bdc2d0d028b456c";
-    private static readonly string FlashHiderTypeId = "550aa4bf4bdc2dd6348b456b";
-    private static readonly string SuppressorTypeId = "550aa4cd4bdc2dd8348b456c";
+    private static readonly string _flashHiderTypeId = "550aa4bf4bdc2dd6348b456b";
+    private static readonly string _suppressorTypeId = "550aa4cd4bdc2dd8348b456c";
 
-    private static readonly string CollimatorTypeId = "55818ad54bdc2ddc698b4569";
-    private static readonly string CompactCollimatorTypeId = "55818acf4bdc2dde698b456b";
-    private static readonly string AssaultScopeTypeId = "55818add4bdc2d5b648b456f";
-    private static readonly string OpticScopeTypeId = "55818ae44bdc2dde698b456c";
-    private static readonly string SpecialScopeTypeId = "55818aeb4bdc2ddc698b456a";
+    private static readonly string[] _opticTypes =
+    {
+        "55818add4bdc2d5b648b456f", // AssaultScopeTypeId
+        "55818ae44bdc2dde698b456c", // OpticScopeTypeId
+        "55818aeb4bdc2ddc698b456a"  // SpecialScopeTypeId
+    };
+    private static readonly string[] _redDotTypes =
+    {
+        "55818ad54bdc2ddc698b4569", // CollimatorTypeId
+        "55818acf4bdc2dde698b456b"  // CompactCollimatorTypeId
+    };
 
-    private static readonly string[] OpticTypes = { AssaultScopeTypeId, OpticScopeTypeId, SpecialScopeTypeId };
-    private static readonly string[] RedDotTypes = { CollimatorTypeId, CompactCollimatorTypeId };
+    // Some weapons don't have their suppressors listed in their mod lists, eventhough they are suppressed.
+    // So, we check for their weapon IDs instead.
+    private static readonly string[] _suppressedWeapons =
+    {
+        "674d6121c09f69dfb201a888" // Aklys Defense Velociraptor .300
+    };
 }
 
 public enum EModType

--- a/SAIN/Components/PlayerComponent.cs
+++ b/SAIN/Components/PlayerComponent.cs
@@ -106,7 +106,7 @@ public class PlayerComponent : MonoBehaviour, IDisposable, ISPlayer
             {
                 Weapon LastWeapon = _currentWeapon;
 #if DEBUG
-                Logger.LogDebug($"[{Player?.Profile.Nickname}] Equipped Weapon [{value?.ShortName}] Last Weapon [{LastWeapon?.ShortName}]");
+                Logger.LogDebug($"[{Player?.Profile.Nickname}] Equipped Weapon [{value?.ShortName?.Localized()}] Last Weapon [{LastWeapon?.ShortName?.Localized()}]");
 #endif
                 _currentWeapon = value;
                 OnWeaponEquipped?.Invoke(value, LastWeapon);
@@ -125,7 +125,7 @@ public class PlayerComponent : MonoBehaviour, IDisposable, ISPlayer
             {
                 Item LastItem = _currentItem;
 #if DEBUG
-                Logger.LogDebug($"[{Player?.Profile.Nickname}] Equipped Item [{value?.ShortName}] Last Item [{LastItem?.ShortName}]");
+                Logger.LogDebug($"[{Player?.Profile.Nickname}] Equipped Item [{value?.ShortName?.Localized()}] Last Item [{LastItem?.ShortName?.Localized()}]");
 #endif
                 _currentItem = value;
                 OnItemEquipped?.Invoke(value, LastItem);

--- a/SAIN/Patches/GenericPatches.cs
+++ b/SAIN/Patches/GenericPatches.cs
@@ -42,12 +42,31 @@ namespace SAIN.Patches.Generic
             }
         }
 
+        // Does not seem to work nor break anything, so let's leave it as is.
         public class SetInHands_Weapon_Patch : ModulePatch
         {
             protected override MethodBase GetTargetMethod()
             {
                 System.Type[] Params = [typeof(Weapon), typeof(Callback<IFirearmHandsController>)];
                 return AccessTools.Method(typeof(Player), nameof(Player.SetInHands), Params);
+            }
+
+            [PatchPostfix]
+            public static void Patch(Player __instance, Weapon weapon)
+            {
+                Helpers.SetItemEquiped(__instance, weapon);
+            }
+        }
+
+        /// <summary>
+        /// Patches method which is called when weapon is swapped.
+        /// </summary>
+        public class Proceed_Weapon_Patch : ModulePatch
+        {
+            protected override MethodBase GetTargetMethod()
+            {
+                System.Type[] Params = [typeof(Weapon), typeof(Callback<IFirearmHandsController>), typeof(bool)];
+                return AccessTools.Method(typeof(Player), nameof(Player.Proceed), Params);
             }
 
             [PatchPostfix]

--- a/SAIN/Patches/GenericPatches.cs
+++ b/SAIN/Patches/GenericPatches.cs
@@ -42,22 +42,6 @@ namespace SAIN.Patches.Generic
             }
         }
 
-        // Does not seem to work nor break anything, so let's leave it as is.
-        public class SetInHands_Weapon_Patch : ModulePatch
-        {
-            protected override MethodBase GetTargetMethod()
-            {
-                System.Type[] Params = [typeof(Weapon), typeof(Callback<IFirearmHandsController>)];
-                return AccessTools.Method(typeof(Player), nameof(Player.SetInHands), Params);
-            }
-
-            [PatchPostfix]
-            public static void Patch(Player __instance, Weapon weapon)
-            {
-                Helpers.SetItemEquiped(__instance, weapon);
-            }
-        }
-
         /// <summary>
         /// Patches method which is called when weapon is swapped.
         /// </summary>


### PR DESCRIPTION
Weapon data (handled by `WeaponInfo` class) is not being updated when a player switches between their weapons. This means the data will be of the one player draws up when they join the raid. For example: If they use unsuppressed weapon as their primary, their suppressed secondary weapon will still use the data of the former, essentially make it "unsuppressed" to bots, and vice versa. The only way to force the data to update is to add or remove a mod from a weapon currently in the hands (with the add/remove attachment animation being played) (handled by `OnWeaponModifiedPatch`).

The fix targets the method which is called when the weapon is being switched to, updating the data every time the weapon is changed. This should be enough to keep the data fresh and correct for the weapon currently being held in a player's hands.

The fix also adds flash hiders/muzzle brakes detection to account for their loudness values, just like suppressors.

Also, weapon like Aklys Velociraptor does not actually have suppressor mod in its mod list, even though its description says it has integrally suppressed barrel. On top of that, BSG's `IsSilenced` does not flag the weapon as suppressed. So, an additional check based on a weapon's ID is added.

Another edge case is DVL suppressed barrel. The mod itself is classified as a "barrel", and its baffle (DVL-10 7.62x51 muzzle device) is also classified as a "flash hider". Thus, an additional check based on a mod's ID is added.

Below is the log after the fix:

<img width="1682" height="866" alt="Screenshot 2026-02-19 014624" src="https://github.com/user-attachments/assets/b6ec594d-a14d-4f15-a90a-fb4ff5670f3e" />