### PR TITLE
fix: inverted difficulty modifier in recoil calculation

### DIFF
--- a/SAIN/Classes/Bot/Info/BotWeaponInfoClass.cs
+++ b/SAIN/Classes/Bot/Info/BotWeaponInfoClass.cs
@@ -135,7 +135,7 @@ public class BotWeaponInfoClass : BotBase
         float DifficultyModifier = Bot.Info.Profile.DifficultyModifier.Scale0to1(_shootSettings.DifficultyScaling).Round100();
 
         FinalModifier = (
-            WeaponClassModifier * RecoilModifier * ErgoModifier * AmmoCaliberModifier * ProficiencyModifier * DifficultyModifier
+            WeaponClassModifier * RecoilModifier * ErgoModifier * AmmoCaliberModifier * ProficiencyModifier / DifficultyModifier
         ).Round100();
     }
 


### PR DESCRIPTION
As I suspected, the recoil calculation is inverted regarding bot difficulty. Easier bots have smaller difficulty values, which if multiply with their recoil values will result in smaller recoil, i.e., more accuracy.

I've attached some screenshots from debugging. Note that I temporary adjusted the clamping values in order to better show the effect before the fix. Bear with higher difficulty value had worse shots while Usec with much lower difficulty value was literally beaming.

<img width="1668" height="668" alt="image" src="https://github.com/user-attachments/assets/dd29c181-88cb-493b-a965-9951d31ea42f" />

<img width="1564" height="163" alt="image" src="https://github.com/user-attachments/assets/76561cbd-85ea-4465-b8c7-374eedd74b69" />
