### PR TITLE
fix: invalid location ID for Woods

### DIFF
--- a/SAIN/Classes/PlayerManager/Info/LocationClass.cs
+++ b/SAIN/Classes/PlayerManager/Info/LocationClass.cs
@@ -112,7 +112,7 @@ public class LocationClass : GameWorldBase, IGameWorldClass
                 break;
 
             case "woods":
-                Location = ELocation.Streets;
+                Location = ELocation.Woods;
                 break;
 
             case "terminal":


### PR DESCRIPTION
Invalid ID means the wrong location settings are being pulled and difficulty settings not being applied properly.

Other locations seem to be correct. I ran a quick test on every map except Streets.