### PR TITLE
Use RemoveFromMap method to extract bot

### DIFF
--- a/SAIN/Components/BotComponent.cs
+++ b/SAIN/Components/BotComponent.cs
@@ -86,7 +86,7 @@ public class BotComponent : BotComponentBase, ISPlayer
 
     public event Action<BotComponent> OnBotActivated;
 
-    public bool IsCheater { get; private set; } = true;
+    public bool IsCheater { get; private set; }
 
     public bool BotActive
     {

--- a/SAIN/Layers/Extract/ExtractAction.cs
+++ b/SAIN/Layers/Extract/ExtractAction.cs
@@ -1,6 +1,7 @@
 ﻿using Comfort.Common;
 using DrakiaXYZ.BigBrain.Brains;
 using EFT;
+using EFT.HealthSystem;
 using EFT.Interactive;
 using SAIN.Components;
 using SAIN.Components.BotController;
@@ -243,7 +244,16 @@ internal class ExtractAction(BotOwner bot) : BotAction(bot, "Extract"), IBotActi
                 Bot.Memory.Extract.ExfilPoint
             );
 
-            Singleton<IBotGame>.Instance.BotDespawn(BotOwner);
+            // For robustness, set HealthController.IsAlive to false.
+            // For some reason, not all EnemyInfo for this bot is removed from other bots. Causing problems for HaveSeenEnemyPatch,
+            // and maybe other places too.
+            if (BotOwner.GetPlayer.HealthController is ActiveHealthController healthController)
+            {
+                healthController.IsAlive = false;
+            }
+
+            // Call RemoveFromMap, used by BSG's Exfil layer
+            BotOwner.LeaveData.RemoveFromMap();
         }
     }
 

--- a/SAIN/Plugin/AssemblyInfoClass.cs
+++ b/SAIN/Plugin/AssemblyInfoClass.cs
@@ -24,7 +24,7 @@ public static class AssemblyInfoClass
 
     public const string SAINGUID = "me.sol.sain";
     public const string SAINName = "SAIN";
-    public const string SAINVersion = "4.4.1";
+    public const string SAINVersion = "4.4.2";
     public const string SAINPresetVersion = "4.4.0";
 
     public const string SPTVersion = "4.0.0";

--- a/SAIN/Plugin/AssemblyInfoClass.cs
+++ b/SAIN/Plugin/AssemblyInfoClass.cs
@@ -23,7 +23,7 @@ public static class AssemblyInfoClass
     public const string EscapeFromTarkov = "EscapeFromTarkov.exe";
 
     public const string SAINGUID = "me.sol.sain";
-    public const string SAINName = "SAIN - Fika Enhanced Edition";
+    public const string SAINName = "SAIN";
     public const string SAINVersion = "4.4.1";
     public const string SAINPresetVersion = "4.4.0";
 

--- a/SAIN/Plugin/ModDetection.cs
+++ b/SAIN/Plugin/ModDetection.cs
@@ -86,11 +86,7 @@ public static class ModDetection
 
             FikaInterop.InitializeInterop();
 
-            Logger.LogInfo($"Fika detected, loading interop compatabilities");
-        }
-        else
-        {
-            Logger.LogInfo("Fika not loaded, Loading Fika.Core");
+            Logger.LogInfo($"SAIN: Project Fika Detected.");
         }
 
         if (Chainloader.PluginInfos.ContainsKey(FikaHeadlessGUID))

--- a/SAINServerMod/SAINServermodMetadata.cs
+++ b/SAINServerMod/SAINServermodMetadata.cs
@@ -10,7 +10,7 @@ public sealed record SAINServermodMetadata : AbstractModMetadata
     public override string Name { get; init; } = "SAIN";
     public override string Author { get; init; } = "Solarint";
     public override List<string>? Contributors { get; init; } = [];
-    public override Version Version { get; init; } = new("4.4.1");
+    public override Version Version { get; init; } = new("4.4.2");
     public override Range SptVersion { get; init; } = new("~4.0.0");
     public override List<string>? Incompatibilities { get; init; } = [];
     public override Dictionary<string, Range>? ModDependencies { get; init; } = [];


### PR DESCRIPTION
This method is used by BSG's exfil layer to _extract_ a bot:
- Disposes the `BotOwner`
- then calls, `IBotGame.BotDespawn`


Included also sets `HealthController.IsAlive = false` on extract, which unfortunately is more of a band-aid fix:
- For some reason, not all EnemyInfo for this bot is removed from other bots. This repeatedly calls `EnemyInfo.HaveSeen` even though the bot has been disposed off. 