### PR TITLE
Fixed Limitations of Interop Method for Ignoring Hearing

### DIFF
--- a/SAIN/Classes/Bot/EnemyClasses/Other/EnemyHearing.cs
+++ b/SAIN/Classes/Bot/EnemyClasses/Other/EnemyHearing.cs
@@ -60,6 +60,11 @@ public class EnemyHearing(EnemyData enemyData) : EnemyBase(enemyData, enemyData.
 
     public EnemyPlace SetHeard(SAINHearingReport report, float currentTime)
     {
+        if (Bot.Hearing.SoundInput.IsIgnoringSounds(report.soundType.IsGunShot()))
+        {
+            return null;
+        }
+
         if (Enemy.IsVisible)
         {
             report.position = Enemy.EnemyPosition;

--- a/SAIN/Classes/Bot/Sense/Hearing/HearingInputClass.cs
+++ b/SAIN/Classes/Bot/Sense/Hearing/HearingInputClass.cs
@@ -23,8 +23,8 @@ public class HearingInputClass : BotSubClass<SAINHearingSensorClass>, IBotClass
     private const float IMPACT_MAX_HEAR_DISTANCE = 50f * 50f;
     private const float IMPACT_DISPERSION = 5f * 5f;
 
-    public bool IgnoreUnderFire { get; private set; }
-    public bool IgnoreHearing { get; private set; }
+    private bool IgnoreUnderFire = false;
+    private bool IgnoreHearing = false;
 
     public bool IsBotDeafened
     {
@@ -81,9 +81,26 @@ public class HearingInputClass : BotSubClass<SAINHearingSensorClass>, IBotClass
     public readonly List<AISoundData> AISoundCachedEvents_Gunshots = [];
     public readonly List<AISoundData> AISoundCachedEvents_Gunshots_Suppressed = [];
 
+    public bool IsIgnoringSounds(bool includingGunfire = true)
+    {
+        if (!Bot.BotActive)
+        {
+            return true;
+        }
+        if (Bot.GameEnding)
+        {
+            return true;
+        }
+        if (IgnoreHearing && (IgnoreUnderFire || !includingGunfire))
+        {
+            return true;
+        }
+        return false;
+    }
+
     public void CheckAddSoundToCache(SoundEvent Sound, float PlayerDistance)
     {
-        if (!Sound.SoundType.IsGunShot() && IgnoreHearing)
+        if (Bot.Hearing.SoundInput.IsIgnoringSounds(Sound.SoundType.IsGunShot()))
         {
             return;
         }
@@ -283,7 +300,7 @@ public class HearingInputClass : BotSubClass<SAINHearingSensorClass>, IBotClass
 
     private void bulletImpacted(EftBulletClass bullet)
     {
-        if (!canHearSounds())
+        if (IsIgnoringSounds(true))
         {
             return;
         }
@@ -337,19 +354,6 @@ public class HearingInputClass : BotSubClass<SAINHearingSensorClass>, IBotClass
             shallReportToSquad = true,
         };
         enemy.Hearing.SetHeard(report, currentTime);
-    }
-
-    private bool canHearSounds()
-    {
-        if (!Bot.BotActive)
-        {
-            return false;
-        }
-        if (Bot.GameEnding)
-        {
-            return false;
-        }
-        return true;
     }
 
     private bool soundListenerStarted(PlayerComponent player)

--- a/SAIN/Classes/Bot/Sense/Hearing/SAINHearingSensorClass.cs
+++ b/SAIN/Classes/Bot/Sense/Hearing/SAINHearingSensorClass.cs
@@ -50,14 +50,15 @@ public class SAINHearingSensorClass : BotComponentClassBase
 
     public void ReactToBulletFlyBy(AISoundData sound, float FlyByDistance)
     {
-        Vector3 EstimatedPosition;
         bool underFire = FlyByDistance <= SAINPlugin.LoadedPreset.GlobalSettings.Mind.MaxUnderFireDistance;
-        if (!SoundInput.IgnoreHearing || underFire)
+        if (SoundInput.IsIgnoringSounds(underFire))
         {
-            EstimatedPosition = Dispersion.CalcRandomizedPosition(sound, 1f);
-            ReactToBulletFlyBy(sound, FlyByDistance, EstimatedPosition, underFire);
-            OnEnemySoundHeard?.Invoke(sound, sound.Enemy);
+            return;
         }
+
+        Vector3 EstimatedPosition = Dispersion.CalcRandomizedPosition(sound, 1f);
+        ReactToBulletFlyBy(sound, FlyByDistance, EstimatedPosition, underFire);
+        OnEnemySoundHeard?.Invoke(sound, sound.Enemy);
     }
 
     public void ReactToHeardSound(AISoundData sound)


### PR DESCRIPTION
Fixed the following issues:
* `HearingInputClass.IgnoreUnderFire` not being used, so bots would never ignore gunfire even after an interop call instructs them to ignore hearing
* `EnemyHearing.SetHeard` not checking if sounds should be ignored (via an interop call)

Additional changes:
* Changed `IgnoreHearing` and `IgnoreUnderFire` to private fields and instead exposed `IsIgnoringSounds` method so other classes can check if sounds should be ignored

These changes will be critical for [Questing Bots](https://github.com/dwesterwick/SPTQuestingBots) releases starting with 0.11.0 Alpha 2. Otherwise, PMCs will immediately switch to a combat state when Scavs spawn in Labyrinth because they won't ignore talking sounds. 