### PR TITLE
Grenades Fix

### DIFF
--- a/SAIN/Patches/Shoot/GrenadePatches.cs
+++ b/SAIN/Patches/Shoot/GrenadePatches.cs
@@ -84,3 +84,48 @@ public class DisableGrenadesPatch : ModulePatch
         return true;
     }
 }
+
+public class DisableGrenadesPatch2 : ModulePatch
+{
+    protected override MethodBase GetTargetMethod()
+    {
+        return AccessTools.PropertyGetter(typeof(BotGrenadeController), nameof(BotGrenadeController.HaveGrenade));
+    }
+
+    [PatchPostfix]
+    public static void Patch(BotGrenadeController __instance, ref bool __result)
+    {
+        if (!__result)
+        {
+            return;
+        }
+
+        var settings = GlobalSettingsClass.Instance.General;
+        if (!settings.BotsUseGrenades)
+        {
+            __result = false;
+            return;
+        }
+
+        if (SAINEnableClass.GetSAIN(__instance.BotOwner_0.ProfileId, out BotComponent bot))
+        {
+            if (!bot.Info.FileSettings.Core.CanGrenade)
+            {
+                __result = false;
+                return;
+            }
+
+            var goalEnemy = bot.EnemyController.GoalEnemy;
+            if (goalEnemy == null)
+            {
+                __result = false;
+                return;
+            }
+
+            if (!settings.BotVsBotGrenade && goalEnemy.IsAI)
+            {
+                __result = false;
+            }
+        }
+    }
+}

--- a/SAIN/Patches/Shoot/GrenadePatches.cs
+++ b/SAIN/Patches/Shoot/GrenadePatches.cs
@@ -51,44 +51,6 @@ public class DisableGrenadesPatch : ModulePatch
 {
     protected override MethodBase GetTargetMethod()
     {
-        return AccessTools.Method(typeof(BotGrenadeToPortal), nameof(BotGrenadeToPortal.method_0));
-    }
-
-    [PatchPrefix]
-    public static bool Patch(BotGrenadeToPortal __instance)
-    {
-        var settings = GlobalSettingsClass.Instance.General;
-        if (!settings.BotsUseGrenades)
-        {
-            return false;
-        }
-
-        if (SAINEnableClass.GetSAIN(__instance.BotOwner_0.ProfileId, out BotComponent bot))
-        {
-            if (!bot.Info.FileSettings.Core.CanGrenade)
-            {
-                return false;
-            }
-
-            var goalEnemy = bot.EnemyController.GoalEnemy;
-            if (goalEnemy == null)
-            {
-                return false;
-            }
-
-            if (!settings.BotVsBotGrenade && goalEnemy.IsAI)
-            {
-                return false;
-            }
-        }
-        return true;
-    }
-}
-
-public class DisableGrenadesPatch2 : ModulePatch
-{
-    protected override MethodBase GetTargetMethod()
-    {
         return AccessTools.PropertyGetter(typeof(BotGrenadeController), nameof(BotGrenadeController.HaveGrenade));
     }
 


### PR DESCRIPTION
This fixes grenades still being used by bots even when config presets are set otherwise. This setting works within SAIN, however other layers are what's causing the bot to still throw a grenade. Previous patch might not be needed anymore with this.

This is more of a quick band-aid fix, so there might/should be a better way!

Side effects may include:
- Cultists may no longer attempt a grenade suicide
- Flashbangs and smoke grenades may not be thrown