### PR TITLE
Change where bots aim

### DIFF
--- a/SAIN/Patches/Aim/BodyPartToShootPatch.cs
+++ b/SAIN/Patches/Aim/BodyPartToShootPatch.cs
@@ -12,16 +12,11 @@ public class BodyPartToShootPatch : ModulePatch
     private static readonly HashSet<BodyPartType> _nonHeadshotBodyPartTypes =
     [
         BodyPartType.body,
-        BodyPartType.leftLeg,
-        BodyPartType.rightLeg,
     ];
 
     private static readonly HashSet<BodyPartType> _upperBodyPartTypes =
     [
         BodyPartType.head,
-        BodyPartType.rightArm,
-        BodyPartType.leftArm,
-        BodyPartType.body,
     ];
 
     protected override MethodBase GetTargetMethod()


### PR DESCRIPTION
Currently, bots aim at the stomach and groin very often, this is due to bots targeting both body and legs. Same deal with the head, instead of aiming at the head with that option, they aim at the body, arms, and head. With this change, bots will no longer aim specifically at the limbs, and if they decide to aim for the head, they will actually do so.

This affects current gameplay quite a bit, bots will be more likely to hit the plate hitbox, making plates all the more useful, and if a bot is able to pen your plate, you'll die faster than if they were instead shooting at the stomach/legs/arms with high pen/low damage ammo. The arm hitbox is also in the way if you're facing the bot shooting you, making armor that has shoulder protection more useful as well.

As for the headshot changes, before, even with 100% headshot chance, bots would only sometimes aim at the head. This makes any bot with a headshot chance actually threatening. And makes helmets no longer a waste of money.